### PR TITLE
Add EpilepsyAssist trigger for hazard response

### DIFF
--- a/selfdrive/monitoring/helpers.py
+++ b/selfdrive/monitoring/helpers.py
@@ -12,6 +12,23 @@ from openpilot.common.transformations.camera import DEVICE_CAMERAS
 
 EventName = log.OnroadEvent.EventName
 
+# ==== BEGIN SDpilot EpilepsyAssist ====
+# Author: Saeed Almansoori
+# License: MIT
+
+_epilepsy_state = {"triggered": False}
+
+def epilepsyassist_trigger(events, EventName):
+  global _epilepsy_state
+  try:
+    if not _epilepsy_state["triggered"] and EventName.driverUnresponsive in events.names:
+      Params().put("RequestHazardLights", b'1')
+      Params().put("RequestRightDrift", b'1')
+      _epilepsy_state["triggered"] = True
+  except Exception:
+    pass
+# ==== END SDpilot EpilepsyAssist ====
+
 # ******************************************************************************************
 #  NOTE: To fork maintainers.
 #  Disabling or nerfing safety features will get you and your users banned from our servers.
@@ -375,7 +392,7 @@ class DriverMonitoring:
 
     if alert is not None:
       self.current_events.add(alert)
-
+    epilepsyassist_trigger(self.current_events, EventName)
 
   def get_state_packet(self, valid=True):
     # build driverMonitoringState packet


### PR DESCRIPTION
## Summary
- add SDpilot EpilepsyAssist helper to request hazard lights and right drift on driver unresponsiveness
- invoke EpilepsyAssist during driver monitoring event update
- remove company identifier from EpilepsyAssist comment

## Testing
- `pytest selfdrive/monitoring/test_monitoring.py` *(fails: No module named 'openpilot.common.params_pyx')*


------
https://chatgpt.com/codex/tasks/task_e_68c27545336083289370114b3ef75c3f